### PR TITLE
space_fix: URL is not a valid `source` parameter for remote_file. `so…

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
 
 default['ixgbevf']['version'] = "3.1.2"
 default['ixgbevf']['package'] = "ixgbevf-#{node['ixgbevf']['version']}.tar.gz"
-default['ixgbevf']['package_url'] = "http://sourceforge.net/projects/e1000/files/ixgbevf stable/#{node['ixgbevf']['version']}/#{node['ixgbevf']['package']}"
+default['ixgbevf']['package_url'] = "http://sourceforge.net/projects/e1000/files/ixgbevf%20stable/#{node['ixgbevf']['version']}/#{node['ixgbevf']['package']}"
 default['ixgbevf']['dir']     = "/usr/src/ixgbevf-#{node['ixgbevf']['version']}"
 default['ixgbevf']['module_flags'] = "InterruptThrottleRate=1,1,1,1,1,1,1,1"
 default['ixgbevf']['disable_ifnames'] = false


### PR DESCRIPTION
space_fix: URL is not a valid `source` parameter for remote_file. `source` must be an absolute URI or an array of URIs.
