### PR TITLE
Fix colliding resource name

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jhohertz@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures ixgbevf'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.1'
+version          '0.1.2'
 
 depends          'yum-epel', '>= 0.0.0'
 depends          'apt', '>= 0.0.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -63,7 +63,7 @@ execute 'dkms_build_ixgbevf' do
   command "dkms build -m ixgbevf -v #{node['ixgbevf']['version']}"
 end
 
-execute 'dkms_add_ixgbevf' do
+execute 'dkms_install_ixgbevf' do
   command "dkms install -m ixgbevf -v #{node['ixgbevf']['version']}"
 end
 


### PR DESCRIPTION
`dkms_add_ixgbevf` is declared twice, which is deprecated in Chef 12, illegal in Chef 13, and makes editing resources in wrapper cookbooks difficult.